### PR TITLE
Ignore comment lines in parser

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,3 +10,8 @@ target_include_directories(stratum INTERFACE src)
 add_executable(example examples/example.cpp)
 
 target_link_libraries(example PRIVATE stratum)
+
+enable_testing()
+add_executable(tests tests/test_parser.cpp)
+target_link_libraries(tests PRIVATE stratum)
+add_test(NAME parser_tests COMMAND tests)

--- a/src/gcode_parser.h
+++ b/src/gcode_parser.h
@@ -4,6 +4,8 @@
 #include <vector>
 #include <fstream>
 #include <sstream>
+#include <string_view>
+#include <cctype>
 
 namespace stratum {
 
@@ -31,9 +33,17 @@ void parse_file(const std::string& path, OutputIt out) {
     }
     std::string line;
     while (std::getline(file, line)) {
-        if (!line.empty()) {
-            *out++ = parse_line(line);
+        // Trim leading whitespace manually
+        std::string_view view(line);
+        while (!view.empty() && std::isspace(static_cast<unsigned char>(view.front()))) {
+            view.remove_prefix(1);
         }
+
+        if (view.empty() || view.front() == ';') {
+            continue;
+        }
+
+        *out++ = parse_line(std::string(view));
     }
 }
 

--- a/tests/test_parser.cpp
+++ b/tests/test_parser.cpp
@@ -1,0 +1,34 @@
+#include <gcode_parser.h>
+#include <vector>
+#include <string>
+#include <fstream>
+#include <iterator>
+#include <cassert>
+#include <cstdio>
+
+int main() {
+    const char* path = "test.gcode";
+    std::ofstream out(path);
+    out << "; full line comment\n";
+    out << "   ; leading whitespace comment\n";
+    out << "G0 X0 Y0\n";
+    out << "   G1 X1 Y1\n";
+    out << "\n";
+    out.close();
+
+    std::vector<stratum::GCodeCommand> cmds;
+    stratum::parse_file(path, std::back_inserter(cmds));
+
+    assert(cmds.size() == 2);
+    assert(cmds[0].command == "G0");
+    assert(cmds[0].arguments.size() == 2);
+    assert(cmds[0].arguments[0] == "X0");
+    assert(cmds[0].arguments[1] == "Y0");
+    assert(cmds[1].command == "G1");
+    assert(cmds[1].arguments.size() == 2);
+    assert(cmds[1].arguments[0] == "X1");
+    assert(cmds[1].arguments[1] == "Y1");
+
+    std::remove(path);
+    return 0;
+}


### PR DESCRIPTION
## Summary
- trim leading whitespace when reading lines in `parse_file`
- skip empty or comment lines
- add tests verifying comment handling
- hook tests into CMake

## Testing
- `cmake ..`
- `cmake --build .`
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_6877fb532cb483268dc6fecc0a87da66