### PR TITLE
Handle file open errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,10 @@ headers now live in the `src/` directory and can be included as:
 #include <gcode_generator.h>
 ```
 
+Both `generate_from_stl` and `parse_file` throw a `std::runtime_error` if the
+specified file cannot be opened. The example program catches these exceptions
+and prints the error message to `stderr`.
+
 ## License
 
 Stratum is licensed under the [MIT License](LICENSE).

--- a/examples/example.cpp
+++ b/examples/example.cpp
@@ -5,14 +5,19 @@
 #include <iterator>
 
 int main() {
-    std::vector<std::string> gcode;
-    stratum::generate_from_stl("example.stl", std::back_inserter(gcode));
-    for (const auto& line : gcode) {
-        std::cout << line << '\n';
-    }
+    try {
+        std::vector<std::string> gcode;
+        stratum::generate_from_stl("example.stl", std::back_inserter(gcode));
+        for (const auto& line : gcode) {
+            std::cout << line << '\n';
+        }
 
-    std::vector<stratum::GCodeCommand> commands;
-    stratum::parse_file("example.gcode", std::back_inserter(commands));
-    std::cout << "Parsed " << commands.size() << " commands\n";
+        std::vector<stratum::GCodeCommand> commands;
+        stratum::parse_file("example.gcode", std::back_inserter(commands));
+        std::cout << "Parsed " << commands.size() << " commands\n";
+    } catch (const std::exception& e) {
+        std::cerr << "Error: " << e.what() << '\n';
+        return 1;
+    }
     return 0;
 }

--- a/src/gcode_generator.h
+++ b/src/gcode_generator.h
@@ -3,6 +3,7 @@
 #include <string>
 #include <fstream>
 #include <sstream>
+#include <stdexcept>
 
 namespace stratum {
 
@@ -10,7 +11,7 @@ template <typename OutputIt>
 void generate_from_stl(const std::string& stl_path, OutputIt out) {
     std::ifstream file(stl_path);
     if (!file.is_open()) {
-        return;
+        throw std::runtime_error("Failed to open " + stl_path);
     }
     std::string line;
     *out++ = "; Begin G-code generated from STL";

--- a/src/gcode_parser.h
+++ b/src/gcode_parser.h
@@ -6,6 +6,7 @@
 #include <sstream>
 #include <string_view>
 #include <cctype>
+#include <stdexcept>
 
 namespace stratum {
 
@@ -29,7 +30,7 @@ template <typename OutputIt>
 void parse_file(const std::string& path, OutputIt out) {
     std::ifstream file(path);
     if (!file.is_open()) {
-        return;
+        throw std::runtime_error("Failed to open " + path);
     }
     std::string line;
     while (std::getline(file, line)) {


### PR DESCRIPTION
## Summary
- throw `std::runtime_error` when files cannot be opened
- catch exceptions in the example program
- document new error behavior in README

## Testing
- `cmake ..`
- `cmake --build .`
- `ctest --output-on-failure`
- `./example`

------
https://chatgpt.com/codex/tasks/task_e_6877fcc57ac08326b68267c56b3ee877