### PR TITLE
Switch to std::filesystem::path APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ headers now live in the `src/` directory and can be included as:
 #include <gcode_generator.h>
 ```
 
+Both APIs accept `std::filesystem::path` objects for file locations.
+
 Both `generate_from_stl` and `parse_file` throw a `std::runtime_error` if the
 specified file cannot be opened. The example program catches these exceptions
 and prints the error message to `stderr`.

--- a/examples/example.cpp
+++ b/examples/example.cpp
@@ -3,17 +3,20 @@
 #include <iostream>
 #include <vector>
 #include <iterator>
+#include <filesystem>
 
 int main() {
     try {
         std::vector<std::string> gcode;
-        stratum::generate_from_stl("example.stl", std::back_inserter(gcode));
+        stratum::generate_from_stl(std::filesystem::path("example.stl"),
+                                   std::back_inserter(gcode));
         for (const auto& line : gcode) {
             std::cout << line << '\n';
         }
 
         std::vector<stratum::GCodeCommand> commands;
-        stratum::parse_file("example.gcode", std::back_inserter(commands));
+        stratum::parse_file(std::filesystem::path("example.gcode"),
+                            std::back_inserter(commands));
         std::cout << "Parsed " << commands.size() << " commands\n";
     } catch (const std::exception& e) {
         std::cerr << "Error: " << e.what() << '\n';

--- a/src/gcode_generator.h
+++ b/src/gcode_generator.h
@@ -4,14 +4,17 @@
 #include <fstream>
 #include <sstream>
 #include <stdexcept>
+#include <filesystem>
 
 namespace stratum {
 
+// Generates G-code comments from the lines of an ASCII STL file.
+// Throws std::runtime_error if the file cannot be opened.
 template <typename OutputIt>
-void generate_from_stl(const std::string& stl_path, OutputIt out) {
+void generate_from_stl(const std::filesystem::path& stl_path, OutputIt out) {
     std::ifstream file(stl_path);
     if (!file.is_open()) {
-        throw std::runtime_error("Failed to open " + stl_path);
+        throw std::runtime_error("Failed to open " + stl_path.string());
     }
     std::string line;
     *out++ = "; Begin G-code generated from STL";

--- a/src/gcode_parser.h
+++ b/src/gcode_parser.h
@@ -7,6 +7,7 @@
 #include <string_view>
 #include <cctype>
 #include <stdexcept>
+#include <filesystem>
 
 namespace stratum {
 
@@ -26,11 +27,13 @@ inline GCodeCommand parse_line(const std::string& line) {
     return cmd;
 }
 
+// Parses a G-code file and writes each command to the output iterator.
+// Throws std::runtime_error if the file cannot be opened.
 template <typename OutputIt>
-void parse_file(const std::string& path, OutputIt out) {
+void parse_file(const std::filesystem::path& path, OutputIt out) {
     std::ifstream file(path);
     if (!file.is_open()) {
-        throw std::runtime_error("Failed to open " + path);
+        throw std::runtime_error("Failed to open " + path.string());
     }
     std::string line;
     while (std::getline(file, line)) {

--- a/tests/test_parser.cpp
+++ b/tests/test_parser.cpp
@@ -5,9 +5,10 @@
 #include <iterator>
 #include <cassert>
 #include <cstdio>
+#include <filesystem>
 
 int main() {
-    const char* path = "test.gcode";
+    const std::filesystem::path path = "test.gcode";
     std::ofstream out(path);
     out << "; full line comment\n";
     out << "   ; leading whitespace comment\n";
@@ -29,6 +30,6 @@ int main() {
     assert(cmds[1].arguments[0] == "X1");
     assert(cmds[1].arguments[1] == "Y1");
 
-    std::remove(path);
+    std::filesystem::remove(path);
     return 0;
 }


### PR DESCRIPTION
## Summary
- modernize API parameters by switching from `std::string` to `std::filesystem::path`
- update example and test code to use path objects
- clarify README about the new parameter types

## Testing
- `cmake ..`
- `cmake --build .`
- `ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_6877fdd4894c8326b78d5781a1914784