### PR TITLE
Add typed G-code argument parsing

### DIFF
--- a/src/gcode_parser.h
+++ b/src/gcode_parser.h
@@ -11,18 +11,37 @@
 
 namespace stratum {
 
+struct Arg {
+    char letter{};
+    double value{};
+};
+
 struct GCodeCommand {
     std::string command;
-    std::vector<std::string> arguments;
+    std::vector<Arg> arguments;
 };
+
+inline Arg parse_arg(const std::string& token) {
+    if (token.size() < 2) {
+        throw std::runtime_error("Invalid G-code argument: " + token);
+    }
+    Arg arg;
+    arg.letter = token[0];
+    try {
+        arg.value = std::stod(token.substr(1));
+    } catch (const std::exception&) {
+        throw std::runtime_error("Invalid numeric value in argument: " + token);
+    }
+    return arg;
+}
 
 inline GCodeCommand parse_line(const std::string& line) {
     std::istringstream iss(line);
     GCodeCommand cmd;
     iss >> cmd.command;
-    std::string arg;
-    while (iss >> arg) {
-        cmd.arguments.push_back(arg);
+    std::string token;
+    while (iss >> token) {
+        cmd.arguments.push_back(parse_arg(token));
     }
     return cmd;
 }

--- a/tests/test_parse_gcode.cpp
+++ b/tests/test_parse_gcode.cpp
@@ -23,16 +23,22 @@ int main() {
     assert(cmds.size() == 3);
     assert(cmds[0].command == "G0");
     assert(cmds[0].arguments.size() == 2);
-    assert(cmds[0].arguments[0] == "X0");
-    assert(cmds[0].arguments[1] == "Y0");
+    assert(cmds[0].arguments[0].letter == 'X');
+    assert(cmds[0].arguments[0].value == 0.0);
+    assert(cmds[0].arguments[1].letter == 'Y');
+    assert(cmds[0].arguments[1].value == 0.0);
     assert(cmds[1].command == "G1");
     assert(cmds[1].arguments.size() == 2);
-    assert(cmds[1].arguments[0] == "X1");
-    assert(cmds[1].arguments[1] == "Y1");
+    assert(cmds[1].arguments[0].letter == 'X');
+    assert(cmds[1].arguments[0].value == 1.0);
+    assert(cmds[1].arguments[1].letter == 'Y');
+    assert(cmds[1].arguments[1].value == 1.0);
     assert(cmds[2].command == "G0");
     assert(cmds[2].arguments.size() == 2);
-    assert(cmds[2].arguments[0] == "X0");
-    assert(cmds[2].arguments[1] == "Y0");
+    assert(cmds[2].arguments[0].letter == 'X');
+    assert(cmds[2].arguments[0].value == 0.0);
+    assert(cmds[2].arguments[1].letter == 'Y');
+    assert(cmds[2].arguments[1].value == 0.0);
 
     std::filesystem::remove(path);
     return 0;

--- a/tests/test_parse_photocuring_gcode.cpp
+++ b/tests/test_parse_photocuring_gcode.cpp
@@ -14,12 +14,32 @@ int main() {
     assert(cmds.size() == 14);
     assert(cmds.front().command == "G21");
     assert(cmds.back().command == "M30");
+    assert(cmds[2].command == "G0");
+    assert(cmds[2].arguments.size() == 4);
+    assert(cmds[2].arguments[0].letter == 'X');
+    assert(cmds[2].arguments[0].value == 0.0);
+    assert(cmds[2].arguments[1].letter == 'Y');
+    assert(cmds[2].arguments[1].value == 0.0);
+    assert(cmds[2].arguments[2].letter == 'Z');
+    assert(cmds[2].arguments[2].value == 10.0);
+    assert(cmds[2].arguments[3].letter == 'F');
+    assert(cmds[2].arguments[3].value == 6000.0);
 
     cmds.clear();
     stratum::parse_file(below, std::back_inserter(cmds));
     assert(cmds.size() == 14);
     assert(cmds.front().command == "G21");
     assert(cmds.back().command == "M30");
+    assert(cmds[2].command == "G0");
+    assert(cmds[2].arguments.size() == 4);
+    assert(cmds[2].arguments[0].letter == 'X');
+    assert(cmds[2].arguments[0].value == 0.0);
+    assert(cmds[2].arguments[1].letter == 'Y');
+    assert(cmds[2].arguments[1].value == 0.0);
+    assert(cmds[2].arguments[2].letter == 'Z');
+    assert(cmds[2].arguments[2].value == -5.0);
+    assert(cmds[2].arguments[3].letter == 'F');
+    assert(cmds[2].arguments[3].value == 6000.0);
 
     return 0;
 }


### PR DESCRIPTION
## Summary
- introduce `Arg` struct with a letter/value pair
- parse arguments into typed `Arg`s instead of raw strings
- update tests to verify numeric argument values

## Testing
- `cmake ..`
- `cmake --build .`
- `ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68780cad23808326bd486746747e13ba