### PR TITLE
Add simple 2D gcode generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,12 @@ The tests in the `tests/` directory demonstrate generating G-code from a hypothe
 
 Both APIs accept `std::filesystem::path` objects for file locations.
 
-Both `generate_from_stl` and `parse_file` throw a `std::runtime_error` if the specified file cannot be opened.
+`generate_from_stl` now accepts an LED spot radius and a set of `(depth,
+exposure)` pairs describing the curing behavior. The function determines the
+XY extents of the STL and emits a simple raster scan for a single layer. The
+feed rate is interpolated from the exposure curve. Both `generate_from_stl`
+and `parse_file` throw a `std::runtime_error` if the specified file cannot be
+opened.
 
 ## License
 

--- a/src/gcode_generator.h
+++ b/src/gcode_generator.h
@@ -5,25 +5,95 @@
 #include <sstream>
 #include <stdexcept>
 #include <filesystem>
+#include <limits>
+#include <vector>
+#include <utility>
 
 namespace Stratum {
 
-// Generates G-code comments from the lines of an ASCII STL file.
-// Throws std::runtime_error if the file cannot be opened.
+// Generates a very simple raster-style G-code toolpath from an ASCII STL file.
+// The STL is treated as a flat 2D shape; the XY extents are used to scan the
+// LED across a single layer. The feed rate is derived from the provided
+// radiant exposure vs. cure depth mapping. Throws std::runtime_error if the
+// file cannot be opened.
+inline double interpolate_exposure(
+    double depth,
+    const std::vector<std::pair<double, double>>& curve) {
+    if (curve.empty()) {
+        return 0.0;
+    }
+    if (depth <= curve.front().first) {
+        return curve.front().second;
+    }
+    for (std::size_t i = 1; i < curve.size(); ++i) {
+        if (depth <= curve[i].first) {
+            double d1 = curve[i - 1].first;
+            double d2 = curve[i].first;
+            double e1 = curve[i - 1].second;
+            double e2 = curve[i].second;
+            return e1 + (e2 - e1) * (depth - d1) / (d2 - d1);
+        }
+    }
+    return curve.back().second;
+}
+
 template <typename OutputIt>
-void generate_from_stl(const std::filesystem::path& stl_path, OutputIt out) {
+void generate_from_stl(const std::filesystem::path& stl_path,
+                       double led_radius,
+                       const std::vector<std::pair<double, double>>& exposure_curve,
+                       OutputIt out) {
     std::ifstream file(stl_path);
     if (!file.is_open()) {
         throw std::runtime_error("Failed to open " + stl_path.string());
     }
-    std::string line;
-    *out++ = "; Begin G-code generated from STL";
-    while (std::getline(file, line)) {
-        if (!line.empty()) {
-            *out++ = std::string("; ") + line;
+
+    double min_x = std::numeric_limits<double>::max();
+    double min_y = std::numeric_limits<double>::max();
+    double max_x = std::numeric_limits<double>::lowest();
+    double max_y = std::numeric_limits<double>::lowest();
+
+    std::string token;
+    while (file >> token) {
+        if (token == "vertex") {
+            double x, y, z;
+            file >> x >> y >> z;
+            min_x = std::min(min_x, x);
+            min_y = std::min(min_y, y);
+            max_x = std::max(max_x, x);
+            max_y = std::max(max_y, y);
         }
     }
+
+    if (min_x == std::numeric_limits<double>::max()) {
+        // No vertices found; default to origin
+        min_x = min_y = max_x = max_y = 0.0;
+    }
+
+    double step = 2.0 * led_radius;
+    double exposure = interpolate_exposure(led_radius, exposure_curve);
+    double feed_rate = exposure > 0.0 ? 1000.0 / exposure : 1000.0;
+
+    *out++ = "; Begin G-code generated from STL";
+    *out++ = "G21"; // millimeter units
+    *out++ = "G90"; // absolute coordinates
+
+    bool forward = true;
+    for (double y = min_y; y <= max_y; y += step) {
+        std::ostringstream start;
+        std::ostringstream end;
+        if (forward) {
+            start << "G1 X" << min_x << " Y" << y << " F" << feed_rate;
+            end << "G1 X" << max_x << " Y" << y;
+        } else {
+            start << "G1 X" << max_x << " Y" << y << " F" << feed_rate;
+            end << "G1 X" << min_x << " Y" << y;
+        }
+        *out++ = start.str();
+        *out++ = end.str();
+        forward = !forward;
+    }
+
     *out++ = "; End G-code";
 }
 
-} // namespace stratum
+} // namespace Stratum

--- a/tests/test_generate_gcode.cpp
+++ b/tests/test_generate_gcode.cpp
@@ -12,14 +12,16 @@ int main() {
     out << "endsolid test\n";
     out.close();
 
-    std::vector<std::string> gcode;
-    Stratum::generate_from_stl(path, std::back_inserter(gcode));
+    std::vector<std::pair<double, double>> curve{{0.0, 1.0}, {1.0, 2.0}};
 
-    assert(gcode.size() == 4);
+    std::vector<std::string> gcode;
+    Stratum::generate_from_stl(path, 1.0, curve, std::back_inserter(gcode));
+
+    assert(gcode.size() >= 6);
     assert(gcode[0] == "; Begin G-code generated from STL");
-    assert(gcode[1] == "; solid test");
-    assert(gcode[2] == "; endsolid test");
-    assert(gcode[3] == "; End G-code");
+    assert(gcode[1] == "G21");
+    assert(gcode[2] == "G90");
+    assert(gcode.back() == "; End G-code");
 
     std::filesystem::remove(path);
     return 0;


### PR DESCRIPTION
## Summary
- expand `generate_from_stl` to produce a very basic 2D raster pattern
- interpolate exposure from a `(depth, exposure)` curve
- adjust tests for the new API
- document the new parameters in the README

## Testing
- `cmake ..`
- `cmake --build .`
- `ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_687812ae98b0832688667ae645c5ffae