### PR TITLE
Enhance G-code comments with mode and power

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,12 +30,14 @@ The tests in the `tests/` directory demonstrate generating G-code from a hypothe
 
 Both APIs accept `std::filesystem::path` objects for file locations.
 
-`generate_from_stl` now accepts an LED spot radius and a set of `(depth,
-exposure)` pairs describing the curing behavior. The function determines the
-XY extents of the STL and emits a simple raster scan for a single layer. The
-feed rate is interpolated from the exposure curve. Both `generate_from_stl`
-and `parse_file` throw a `std::runtime_error` if the specified file cannot be
-opened.
+`generate_from_stl` accepts an LED spot radius and a set of `(depth,
+exposure)` pairs describing the curing behavior. Additional parameters
+specify the printing mode (`"LCD"` or `"SLA"`), the power level for the
+light source, and the optional LED bitmask path used when operating in LCD
+mode. The function determines the XY extents of the STL and emits a simple
+raster scan for a single layer. The feed rate is interpolated from the
+exposure curve. Both `generate_from_stl` and `parse_file` throw a
+`std::runtime_error` if the specified file cannot be opened.
 
 ## License
 

--- a/src/gcode_generator.h
+++ b/src/gcode_generator.h
@@ -41,6 +41,9 @@ template <typename OutputIt>
 void generate_from_stl(const std::filesystem::path& stl_path,
                        double led_radius,
                        const std::vector<std::pair<double, double>>& exposure_curve,
+                       const std::string& mode,
+                       double power,
+                       const std::string& bitmask_path,
                        OutputIt out) {
     std::ifstream file(stl_path);
     if (!file.is_open()) {
@@ -74,6 +77,37 @@ void generate_from_stl(const std::filesystem::path& stl_path,
     double feed_rate = exposure > 0.0 ? 1000.0 / exposure : 1000.0;
 
     *out++ = "; Begin G-code generated from STL";
+    *out++ = "; Photopolymerization toolpath";
+    {
+        std::ostringstream line;
+        line << "; Mode: " << mode;
+        *out++ = line.str();
+    }
+    {
+        std::ostringstream line;
+        line << "; Power: " << power;
+        *out++ = line.str();
+    }
+    if (mode == "LCD") {
+        std::ostringstream line;
+        line << "; LED bitmask: " << bitmask_path;
+        *out++ = line.str();
+    }
+    {
+        std::ostringstream line;
+        line << "; LED radius: " << led_radius << " mm";
+        *out++ = line.str();
+    }
+    {
+        std::ostringstream line;
+        line << "; Step size: " << step << " mm";
+        *out++ = line.str();
+    }
+    {
+        std::ostringstream line;
+        line << "; Feed rate: " << feed_rate << " mm/min";
+        *out++ = line.str();
+    }
     *out++ = "G21"; // millimeter units
     *out++ = "G90"; // absolute coordinates
 

--- a/tests/test_generate_gcode.cpp
+++ b/tests/test_generate_gcode.cpp
@@ -15,12 +15,22 @@ int main() {
     std::vector<std::pair<double, double>> curve{{0.0, 1.0}, {1.0, 2.0}};
 
     std::vector<std::string> gcode;
-    Stratum::generate_from_stl(path, 1.0, curve, std::back_inserter(gcode));
+    Stratum::generate_from_stl(path,
+                               1.0,
+                               curve,
+                               "LCD",
+                               1.0,
+                               "mask.bin",
+                               std::back_inserter(gcode));
 
-    assert(gcode.size() >= 6);
+    assert(gcode.size() >= 10);
     assert(gcode[0] == "; Begin G-code generated from STL");
-    assert(gcode[1] == "G21");
-    assert(gcode[2] == "G90");
+    assert(gcode[1] == "; Photopolymerization toolpath");
+    assert(gcode[2] == "; Mode: LCD");
+    assert(gcode[3] == "; Power: 1");
+    assert(gcode[4] == "; LED bitmask: mask.bin");
+    assert(gcode[8] == "G21");
+    assert(gcode[9] == "G90");
     assert(gcode.back() == "; End G-code");
 
     std::filesystem::remove(path);


### PR DESCRIPTION
## Summary
- extend `generate_from_stl` to include printing mode, power, and LED bitmask
- document the new parameters in README
- update tests for the richer G-code output

## Testing
- `cmake ..`
- `make -j$(nproc)`
- `ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_688117f958088326860d3b14a17b4f34