### PR TITLE
Embed layer bitmasks in generated G-code

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,10 +33,11 @@ Both APIs accept `std::filesystem::path` objects for file locations.
 `generateFromStl` accepts an LED spot radius and a set of `(depth,
 exposure)` pairs describing the curing behavior. Additional parameters
 specify the printing mode (`Stratum::PrintMode::LCD` or
-`Stratum::PrintMode::SLA`), the power level for the light source, and an
-optional LED bitmask path used only in LCD mode. The function determines
-the XY extents of the STL and emits a simple raster scan for a single
-layer. The feed rate is interpolated from the exposure curve. Both
+`Stratum::PrintMode::SLA`) and the power level for the light source.
+Bitmasks for each layer are generated automatically and emitted as
+comments in the G-code. The function determines the XY extents of the
+STL and emits a simple raster scan for a single layer. The feed rate is
+interpolated from the exposure curve. Both
 `generateFromStl` and `parseFile` throw a `std::runtime_error` if the
 specified file cannot be opened.
 

--- a/tests/test_generate_gcode.cpp
+++ b/tests/test_generate_gcode.cpp
@@ -20,17 +20,18 @@ int main() {
                              curve,
                              Stratum::PrintMode::LCD,
                              1.0,
-                             std::filesystem::path("mask.bin"),
                              std::back_inserter(gcode));
 
-    assert(gcode.size() >= 10);
+    assert(gcode.size() >= 13);
     assert(gcode[0] == "; Begin G-code generated from STL");
     assert(gcode[1] == "; Photopolymerization toolpath");
     assert(gcode[2] == "; Mode: LCD");
     assert(gcode[3] == "; Power: 1");
-    assert(gcode[4] == "; LED bitmask: mask.bin");
-    assert(gcode[8] == "G21");
-    assert(gcode[9] == "G90");
+    assert(gcode[7] == "G21");
+    assert(gcode[8] == "G90");
+    assert(gcode[9].rfind("; Layer 0 bitmask:", 0) == 0);
+    assert(gcode[10].rfind("G1", 0) == 0);
+    assert(gcode[11].rfind("G1", 0) == 0);
     assert(gcode.back() == "; End G-code");
 
     std::filesystem::remove(path);


### PR DESCRIPTION
## Summary
- remove bitmask file argument from `generateFromStl`
- automatically generate a simple bitmask for each layer
- include the bitmask as a comment in the output G-code
- update README
- adjust generate test for new behaviour

## Testing
- `cmake ..`
- `cmake --build .`
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_688127e79d4083269d35603b4efb234d