### PR TITLE
Fix tests for new API

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,16 +30,13 @@ The tests in the `tests/` directory demonstrate generating G-code from a hypothe
 
 Both APIs accept `std::filesystem::path` objects for file locations.
 
-`generateFromStl` accepts an LED spot radius and a set of `(depth,
-exposure)` pairs describing the curing behavior. Additional parameters
-specify the printing mode (`Stratum::PrintMode::LCD` or
-`Stratum::PrintMode::SLA`) and the power level for the light source.
-Bitmasks for each layer are generated automatically and emitted as
-comments in the G-code. The function determines the XY extents of the
-STL and emits a simple raster scan for a single layer. The feed rate is
-interpolated from the exposure curve. Both
-`generateFromStl` and `parseFile` throw a `std::runtime_error` if the
-specified file cannot be opened.
+`generateGCode` takes an ASCII STL file along with either a
+`Stratum::LCDConfig` or `Stratum::SLAConfig` structure describing the
+printer setup. The resulting G-code is written through an output
+iterator.  Masks for each layer are produced automatically and stored as
+1‑bit PNG images.  `parseFile` reads an existing G-code file and
+produces a sequence of `Stratum::GCodeCommand` objects.  Both functions
+throw `std::runtime_error` if the requested file cannot be opened.
 
 ## License
 

--- a/tests/test_generate_gcode.cpp
+++ b/tests/test_generate_gcode.cpp
@@ -9,31 +9,34 @@ int main() {
     const std::filesystem::path path = "test.stl";
     std::ofstream out(path);
     out << "solid test\n";
+    out << "  facet normal 0 0 1\n";
+    out << "    outer loop\n";
+    out << "      vertex 0 0 0\n";
+    out << "      vertex 1 0 1\n";
+    out << "      vertex 0 1 0\n";
+    out << "    endloop\n";
+    out << "  endfacet\n";
     out << "endsolid test\n";
     out.close();
 
-    std::vector<std::pair<double, double>> curve{{0.0, 1.0}, {1.0, 2.0}};
+    Stratum::LCDConfig cfg;
+    cfg.cols = 5;
+    cfg.rows = 5;
+    cfg.led_radius = 0.5;
+    cfg.layer_height = 1.0;
+    cfg.final_lift_mm = 0.0;
+    cfg.png_dir = "layers_out";
 
     std::vector<std::string> gcode;
-    Stratum::generateFromStl(path,
-                             1.0,
-                             curve,
-                             Stratum::PrintMode::LCD,
-                             1.0,
-                             std::back_inserter(gcode));
+    Stratum::generateGCode(path, cfg, std::back_inserter(gcode));
 
-    assert(gcode.size() >= 13);
-    assert(gcode[0] == "; Begin G-code generated from STL");
-    assert(gcode[1] == "; Photopolymerization toolpath");
-    assert(gcode[2] == "; Mode: LCD");
-    assert(gcode[3] == "; Power: 1");
-    assert(gcode[7] == "G21");
-    assert(gcode[8] == "G90");
-    assert(gcode[9].rfind("; Layer 0 bitmask:", 0) == 0);
-    assert(gcode[10].rfind("G1", 0) == 0);
-    assert(gcode[11].rfind("G1", 0) == 0);
-    assert(gcode.back() == "; End G-code");
+    assert(gcode.size() >= 8);
+    assert(gcode[0].rfind("; **** MSLA Print ****", 0) == 0);
+    assert(gcode[1] == "G28");
+    assert(gcode[2] == "G90");
+    assert(gcode.back().rfind("; PNG layers stored in", 0) == 0);
 
     std::filesystem::remove(path);
+    std::filesystem::remove_all(cfg.png_dir);
     return 0;
 }

--- a/tests/test_parse_gcode.cpp
+++ b/tests/test_parse_gcode.cpp
@@ -5,6 +5,7 @@
 #include <iterator>
 #include <cassert>
 #include <filesystem>
+#include <variant>
 
 int main() {
     const std::filesystem::path path = "test.gcode";
@@ -24,21 +25,27 @@ int main() {
     assert(cmds[0].command == "G0");
     assert(cmds[0].arguments.size() == 2);
     assert(cmds[0].arguments[0].letter == 'X');
-    assert(cmds[0].arguments[0].value == 0.0);
+    assert(std::holds_alternative<double>(cmds[0].arguments[0].value));
+    assert(std::get<double>(cmds[0].arguments[0].value) == 0.0);
     assert(cmds[0].arguments[1].letter == 'Y');
-    assert(cmds[0].arguments[1].value == 0.0);
+    assert(std::holds_alternative<double>(cmds[0].arguments[1].value));
+    assert(std::get<double>(cmds[0].arguments[1].value) == 0.0);
     assert(cmds[1].command == "G1");
     assert(cmds[1].arguments.size() == 2);
     assert(cmds[1].arguments[0].letter == 'X');
-    assert(cmds[1].arguments[0].value == 1.0);
+    assert(std::holds_alternative<double>(cmds[1].arguments[0].value));
+    assert(std::get<double>(cmds[1].arguments[0].value) == 1.0);
     assert(cmds[1].arguments[1].letter == 'Y');
-    assert(cmds[1].arguments[1].value == 1.0);
+    assert(std::holds_alternative<double>(cmds[1].arguments[1].value));
+    assert(std::get<double>(cmds[1].arguments[1].value) == 1.0);
     assert(cmds[2].command == "G0");
     assert(cmds[2].arguments.size() == 2);
     assert(cmds[2].arguments[0].letter == 'X');
-    assert(cmds[2].arguments[0].value == 0.0);
+    assert(std::holds_alternative<double>(cmds[2].arguments[0].value));
+    assert(std::get<double>(cmds[2].arguments[0].value) == 0.0);
     assert(cmds[2].arguments[1].letter == 'Y');
-    assert(cmds[2].arguments[1].value == 0.0);
+    assert(std::holds_alternative<double>(cmds[2].arguments[1].value));
+    assert(std::get<double>(cmds[2].arguments[1].value) == 0.0);
 
     std::filesystem::remove(path);
     return 0;

--- a/tests/test_parse_photocuring_gcode.cpp
+++ b/tests/test_parse_photocuring_gcode.cpp
@@ -4,6 +4,7 @@
 #include <iterator>
 #include <cassert>
 #include <filesystem>
+#include <variant>
 
 int main() {
     const std::filesystem::path above = "../tests/gcode/photocuring_above.gcode";
@@ -17,13 +18,17 @@ int main() {
     assert(cmds[2].command == "G0");
     assert(cmds[2].arguments.size() == 4);
     assert(cmds[2].arguments[0].letter == 'X');
-    assert(cmds[2].arguments[0].value == 0.0);
+    assert(std::holds_alternative<double>(cmds[2].arguments[0].value));
+    assert(std::get<double>(cmds[2].arguments[0].value) == 0.0);
     assert(cmds[2].arguments[1].letter == 'Y');
-    assert(cmds[2].arguments[1].value == 0.0);
+    assert(std::holds_alternative<double>(cmds[2].arguments[1].value));
+    assert(std::get<double>(cmds[2].arguments[1].value) == 0.0);
     assert(cmds[2].arguments[2].letter == 'Z');
-    assert(cmds[2].arguments[2].value == 10.0);
+    assert(std::holds_alternative<double>(cmds[2].arguments[2].value));
+    assert(std::get<double>(cmds[2].arguments[2].value) == 10.0);
     assert(cmds[2].arguments[3].letter == 'F');
-    assert(cmds[2].arguments[3].value == 6000.0);
+    assert(std::holds_alternative<double>(cmds[2].arguments[3].value));
+    assert(std::get<double>(cmds[2].arguments[3].value) == 6000.0);
 
     cmds.clear();
     Stratum::parseFile(below, std::back_inserter(cmds));
@@ -33,13 +38,17 @@ int main() {
     assert(cmds[2].command == "G0");
     assert(cmds[2].arguments.size() == 4);
     assert(cmds[2].arguments[0].letter == 'X');
-    assert(cmds[2].arguments[0].value == 0.0);
+    assert(std::holds_alternative<double>(cmds[2].arguments[0].value));
+    assert(std::get<double>(cmds[2].arguments[0].value) == 0.0);
     assert(cmds[2].arguments[1].letter == 'Y');
-    assert(cmds[2].arguments[1].value == 0.0);
+    assert(std::holds_alternative<double>(cmds[2].arguments[1].value));
+    assert(std::get<double>(cmds[2].arguments[1].value) == 0.0);
     assert(cmds[2].arguments[2].letter == 'Z');
-    assert(cmds[2].arguments[2].value == -5.0);
+    assert(std::holds_alternative<double>(cmds[2].arguments[2].value));
+    assert(std::get<double>(cmds[2].arguments[2].value) == -5.0);
     assert(cmds[2].arguments[3].letter == 'F');
-    assert(cmds[2].arguments[3].value == 6000.0);
+    assert(std::holds_alternative<double>(cmds[2].arguments[3].value));
+    assert(std::get<double>(cmds[2].arguments[3].value) == 6000.0);
 
     return 0;
 }


### PR DESCRIPTION
## Summary
- update tests to use `generateGCode` and new parser structures
- refresh README usage section for the new config-based API

## Testing
- `cmake ..` *(fails: Cannot find external/lodepng due to environment)*

------
https://chatgpt.com/codex/tasks/task_e_6887a93c0a0c8326b33270da5b1371f9